### PR TITLE
Adapt comment sniffs to recent phpcs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,46 @@
-Symfony2 PHP CodeSniffer Coding Standard
-========================================
+# Symfony2 PHP CodeSniffer Coding Standard
 
 This was taken originally from https://github.com/opensky/Symfony2-coding-standard but reuploaded as this repo came down.
 
-A code standard to check against the [Symfony coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
+A code standard to check against the [Symfony coding standards](http://symfony.com/doc/current/contributing/code/standards.html).
 
-Installation
-------------
+## Installation
 
-1. Install phpcs:
+1. Install phpcs (>= 2.3.0):
 
+        # With pear
         pear install PHP_CodeSniffer
+        
+        # OR with composer (system wide)
+        composer global require 'squizlabs/php_codesniffer=*'
+        
+    You can also refer to the [official documentation](https://github.com/squizlabs/PHP_CodeSniffer).
 
-2. Find your PEAR directory:
+2. Find your phpcs directory
 
+    If you used PEAR installation:
+    
         pear config-show | grep php_dir
+        
+    If you used composer, it should be ``~/.composer/vendor/squizlabs/php_codesniffer``.
 
 3. Copy, symlink or check out this repo to a folder called Symfony2 inside the
    phpcs `Standards` directory:
 
-        cd /path/to/pear/PHP/CodeSniffer/Standards
-        git clone git://github.com/Bladrak/Symfony2-coding-standard.git Symfony2
+        cd /path/to/phpcs/CodeSniffer/Standards
+        git clone git://github.com/ekino/Symfony2-coding-standard.git Symfony2
 
 4. Set Symfony2 as your default coding standard:
 
         phpcs --config-set default_standard Symfony2
 
-5. ...
-
-6. Profit!
+5. Profit!
 
         cd /path/to/my/project
         phpcs
         phpcs path/to/my/file.php
 
-
-Contributing
-------------
+## Contributing
 
 If you do contribute code to these sniffs, please make sure it conforms to the PEAR
 coding standard and that the Symfony2-coding-standard unit tests still pass.

--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -14,8 +14,8 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === false) {
-    $error = 'Class PHP_CodeSniffer_CommentParser_ClassCommentParser not found';
+if (class_exists('PHP_CodeSniffer_Tokenizers_Comment', true) === false) {
+    $error = 'Class PHP_CodeSniffer_Tokenizers_Comment not found';
     throw new PHP_CodeSniffer_Exception($error);
 }
 


### PR DESCRIPTION
This PR fixes some sniffs incompatibilities for recent phpcs versions.
