### PR TITLE
Allow ; to be indented differently than func calls

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -74,6 +74,9 @@
     <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
         <severity>0</severity>
     </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterCloseBracket">
+        <severity>0</severity>
+    </rule>
 
     <rule ref="Symfony2.Commenting.FunctionComment.MissingParamComment">
         <severity>0</severity>


### PR DESCRIPTION
This will allow the following:

``` php
$formMapper
    ->with('General', ['class' => 'col-md-12'])
        ->add('name')
    ->end()
;
```
